### PR TITLE
Enabling Systemd on the distro side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+systemd/nslogin/nslogin

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+**/.vscode
 systemd/nslogin/nslogin

--- a/systemd/nslogin/.clang-format
+++ b/systemd/nslogin/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: LLVM
+ColumnLimit: 120
+DeriveLineEnding: true
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+UseCRLF: false
+UseTab: Never

--- a/systemd/nslogin/.clang-tidy
+++ b/systemd/nslogin/.clang-tidy
@@ -1,3 +1,6 @@
-Checks: 'bugprone-*,performance-*,clang-analyzer-*'
+# -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling generates warnings suggesting to use function
+# snprintf_s, printf_s etc which are optional per C standard and apparently GCC opted out.
+
+Checks: 'bugprone-*,performance-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
 HeaderFilterRegex: .+\.h$
 

--- a/systemd/nslogin/.clang-tidy
+++ b/systemd/nslogin/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: 'bugprone-*,performance-*,clang-analyzer-*'
+HeaderFilterRegex: .+\.h$
+

--- a/systemd/nslogin/Makefile
+++ b/systemd/nslogin/Makefile
@@ -1,0 +1,3 @@
+nslogin: nslogin.c
+	$(CC) -Wall -Wextra -pedantic nslogin.c -o nslogin
+	sudo chown root:root nslogin && sudo chmod a+s nslogin

--- a/systemd/nslogin/Makefile
+++ b/systemd/nslogin/Makefile
@@ -1,11 +1,12 @@
 SRC=nslogin.c
 LIBS=-lsystemd
-CFLAGS=-Wall -Wextra -pedantic
+CFLAGS=-Wall -Wextra -Wconversion -pedantic
+CMODEFLAGS=-O0 -g -DDEBUG
 POSTBUILD=sudo chown root:root $@ && sudo chmod a+s $@
 LINTER=clang-tidy-12
 
 nslogin: $(SRC)
-	$(CC) $(CFLAGS) $(SRC) $(LIBS) -o $@
+	$(CC) $(CFLAGS) $(CMODEFLAGS) $(SRC) $(LIBS) -o $@
 	$(POSTBUILD)
 
 .PHONY: lint
@@ -13,3 +14,5 @@ nslogin: $(SRC)
 lint:
 	$(LINTER) $(SRC) -- $(CFLAGS) $(LIBS) 
 
+Release: CMODEFLAGS=-O3 -DNDEBUG
+Release: nslogin

--- a/systemd/nslogin/Makefile
+++ b/systemd/nslogin/Makefile
@@ -1,3 +1,15 @@
-nslogin: nslogin.c
-	$(CC) -Wall -Wextra -pedantic nslogin.c -o nslogin
-	sudo chown root:root nslogin && sudo chmod a+s nslogin
+SRC=nslogin.c
+LIBS=-lsystemd
+CFLAGS=-Wall -Wextra -pedantic
+POSTBUILD=sudo chown root:root $@ && sudo chmod a+s $@
+LINTER=clang-tidy-12
+
+nslogin: $(SRC)
+	$(CC) $(CFLAGS) $(SRC) $(LIBS) -o $@
+	$(POSTBUILD)
+
+.PHONY: lint
+
+lint:
+	$(LINTER) $(SRC) -- $(CFLAGS) $(LIBS) 
+

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -181,7 +181,7 @@ static pid_t pid_from_path(const char *path, int basenameOffset) {
 static int symlink_basename_cmp(const char *symlink, const char *name, int length) {
     char target[PATH_MAX];
     ssize_t len = readlink(symlink, target, PATH_MAX);
-    if (len == -1){
+    if (len == -1) {
         perror(symlink);
         return -5;
     }

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -156,7 +156,7 @@ static bool is_systemd_startup_complete(sd_bus *bus) {
 }
 
 /// Returns 0 if the basename of the symlink target matches the expected name up to length.
-static int symlink_basename_cmp(const char *symlink, const char *name, int length) {
+static int symlink_basename_cmp(const char *symlink, const char *name, size_t length) {
     char target[PATH_MAX];
     ssize_t len = readlink(symlink, target, PATH_MAX);
     if (len == -1) {
@@ -189,7 +189,7 @@ static bool match_owner(const char *path, uid_t uid, gid_t gid) {
 pid_t find_systemd(void) {
     struct procInfo {
         const char *basename;
-        int basenameSize;
+        size_t basenameSize;
         uid_t owner;
     };
 
@@ -214,7 +214,7 @@ bool wait_on_systemd(void) {
     bool systemdStarted = true;
     int waitCounts = 0;
     int busOk = -1;
-    const int timeoutUs = 500000;
+    const unsigned int timeoutUs = 500000;
     const int loopMax = 19;
     for (busOk = sd_bus_default_system(&bus); busOk < 0 && waitCounts < loopMax; waitCounts++) {
         usleep(timeoutUs); // 500 ms.

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -265,7 +265,11 @@ void continue_as_child(void) {
 #define TARGET_NS_COUNT 2
 int enter_target_ns(pid_t PID) {
     char currentDir[PATH_MAX];
-    getcwd(currentDir, PATH_MAX);
+    bool preserveDir = true;
+    // If getcwd fails, we give up on keeping PWD.
+    if (getcwd(currentDir, PATH_MAX) == NULL) {
+        preserveDir = false;
+    }
 
     struct {
         int nstype;
@@ -299,6 +303,10 @@ int enter_target_ns(pid_t PID) {
         close(ns[i].nsfd);
     }
 
-    chdir(currentDir);
+    if (preserveDir) {
+        if(chdir(currentDir)!=0){
+            perror("Attempt to keep working directory");
+        }
+    }
     return 0;
 }

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -16,11 +16,6 @@
  */
 
 #define _GNU_SOURCE
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 700
-#endif
-#define _LARGEFILE64_SOURCE
-#define _FILE_OFFSET_BITS 64
 
 #include <ctype.h>
 #include <dirent.h>

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -15,6 +15,9 @@
  *
  */
 
+// That's GCC's way of letting us access GNU extensions. We either define this macro in this source file, before all
+// includes or on the Makefile.
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _GNU_SOURCE
 
 #include <fcntl.h>

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -163,8 +163,9 @@ static pid_t pid_from_path(const char *path, long basenameOffset) {
     pidString[pidLenght] = '\0';
     int pid = atoi(pidString);
     if (pid == 0) {
-        perror("Failed to determine PID from path");
-        fprintf(stderr, "Failed pid string was %s", pidString);
+        char msg[80];
+        snprintf(msg, 80, "Failed to determine PID from path %s", pidString);
+        perror(msg);
         return 0;
     }
     return (pid_t)pid;
@@ -186,7 +187,6 @@ static int symlink_basename_cmp(const char *symlink, const char *name, int lengt
         return -5;
     }
     targetBasename += 1;
-    printf("%s --> %s\n", symlink, target);
     return strncmp(targetBasename, name, length);
 }
 
@@ -300,8 +300,9 @@ int enter_target_ns(pid_t PID) {
         }
         int fd = open(nsPath, O_RDONLY);
         if (fd <= 0) {
-            fprintf(stderr, "\tpath was %s\n", nsPath);
-            perror("Failed to open namespace file descriptor");
+            char msg[80];
+            snprintf(msg, 80, "Failed to open namespace file descriptor from path %s", nsPath);
+            perror(msg);
             return -2;
         }
         ns[i].nsfd = fd;

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
         exit(4);
     }
 
-    // Drop priviledges back as the current user
+    // Drop privileges back as the current user
     if (seteuid(uid) != 0) {
         perror("seteuid back as user");
         exit(5);
@@ -211,8 +211,8 @@ pid_t find_systemd(void) {
 
     struct procInfo systemd = {"systemd", 7, 0};
     char exeLinkPath[80] = {'\0'};
-    for (int32_t pidCanditate = 10; pidCanditate < INT32_MAX; pidCanditate++) {
-        snprintf(exeLinkPath, 80, "/proc/%d/exe", pidCanditate);
+    for (int32_t pidCandidate = 10; pidCandidate < INT32_MAX; pidCandidate++) {
+        snprintf(exeLinkPath, 80, "/proc/%d/exe", pidCandidate);
         int res = symlink_basename_cmp(exeLinkPath, systemd.basename, systemd.basenameSize);
         if (res != 0) {
             continue;

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -48,6 +48,8 @@ void continue_as_child(void);
 #define RESTART_MSG "Please terminate this instance by running \"wsl -t <distro>\" from Windows shell and try again.\n"
 
 int main(int argc, char *argv[]) {
+    uid_t uid = getuid();
+    gid_t gid = getgid();
 #ifndef NDEBUG
     printf("Starting nslogin with arguments: ");
     for (int i = 0; i < argc; i++) {
@@ -55,8 +57,6 @@ int main(int argc, char *argv[]) {
     }
     putc('\n', stdout);
     // print euid
-    uid_t uid = getuid();
-    gid_t gid = getgid();
     printf("euid: %d\n", geteuid());
     printf("uid: %d\n", getuid());
 #endif
@@ -177,8 +177,8 @@ static int symlink_basename_cmp(const char *symlink, const char *name, int lengt
 static bool match_owner(const char *path, uid_t uid, gid_t gid) {
     struct stat fileStat;
     if (stat(path, &fileStat) != 0) {
-        char msg[80];
-        snprintf(msg, 80, "Failed to stat %s", path);
+        char msg[96];
+        snprintf(msg, 96, "Failed to stat %s", path);
         perror(msg);
         return false;
     }
@@ -194,9 +194,9 @@ pid_t find_systemd(void) {
     };
 
     struct procInfo systemd = {"systemd", 7, 0};
-    char exeLinkPath[80] = {'\0'};
+    char exeLinkPath[16] = {'\0'};
     for (int16_t pidCandidate = 2; pidCandidate < INT16_MAX; pidCandidate++) {
-        snprintf(exeLinkPath, 80, "/proc/%" SCNd16 "/exe", pidCandidate);
+        snprintf(exeLinkPath, 16, "/proc/%" SCNd16 "/exe", pidCandidate);
         int res = symlink_basename_cmp(exeLinkPath, systemd.basename, systemd.basenameSize);
         if (res != 0) {
             continue;

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -17,10 +17,7 @@
 
 #define _GNU_SOURCE
 
-#include <ctype.h>
-#include <dirent.h>
 #include <fcntl.h>
-#include <ftw.h>
 #include <linux/limits.h>
 #include <pwd.h>
 #include <sched.h>
@@ -29,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <systemd/sd-bus.h>
 #include <unistd.h>

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -45,6 +45,8 @@ int enter_target_ns(int PID);
 /// Stops this process in favor or running it as child.
 void continue_as_child(void);
 
+#define RESTART_MSG "Please terminate this instance by running \"wsl -t <distro>\" from Windows shell and try again.\n"
+
 int main(int argc, char *argv[]) {
 #ifndef NDEBUG
     printf("Starting nslogin with arguments: ");
@@ -61,10 +63,12 @@ int main(int argc, char *argv[]) {
     // Wait for systemd to be ready
     pid_t systemdPid = find_systemd();
     if (systemdPid == 0) {
-        perror("Could not find systemd PID");
+        fprintf(stderr, "Systemd is not running. " RESTART_MSG);
         exit(1);
     }
-    while (!wait_on_systemd()) {
+    if (!wait_on_systemd()) {
+        fprintf(stderr, RESTART_MSG);
+        exit(1);
     }
 
     // Gain root privilege

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -178,7 +178,7 @@ static pid_t pid_from_path(const char *path, int basenameOffset) {
 }
 
 /// Returns 0 if the basename of the symlink target matches the expected name up to length.
-int symlink_basename_cmp(const char *symlink, const char *name, int length) {
+static int symlink_basename_cmp(const char *symlink, const char *name, int length) {
     char target[PATH_MAX];
     ssize_t len = readlink(symlink, target, PATH_MAX);
     if (len == -1){
@@ -197,7 +197,7 @@ int symlink_basename_cmp(const char *symlink, const char *name, int length) {
 }
 
 /// Returns the systemd PID if found, or zero otherwise.
-int check_entry_for_systemd(const char *path, const struct stat *info, const int typeflag, struct FTW *pathinfo) {
+static int check_entry_for_systemd(const char *path, const struct stat *info, const int typeflag, struct FTW *pathinfo) {
     struct procInfo {
         const char *basename;
         int basenameSize;

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -165,7 +165,7 @@ static pid_t pid_from_path(const char *path, int basenameOffset) {
         perror("Cannot determine where pid starts in path");
         return 0;
     }
-    int pidLenght = path + basenameOffset - pidStarts - 2;
+    ssize_t pidLenght = path + basenameOffset - pidStarts - 2;
     strncpy(pidString, pidStarts + 1, pidLenght);
     pidString[pidLenght] = '\0';
     int pid = atoi(pidString);
@@ -180,8 +180,8 @@ static pid_t pid_from_path(const char *path, int basenameOffset) {
 /// Returns 0 if the basename of the symlink target matches the expected name up to length.
 int symlink_basename_cmp(const char *symlink, const char *name, int length) {
     char target[PATH_MAX];
-    int len = readlink(symlink, target, PATH_MAX);
-    if (len == (ssize_t)-1) {
+    ssize_t len = readlink(symlink, target, PATH_MAX);
+    if (len == -1){
         perror(symlink);
         return -5;
     }
@@ -200,7 +200,7 @@ int symlink_basename_cmp(const char *symlink, const char *name, int length) {
 int check_entry_for_systemd(const char *path, const struct stat *info, const int typeflag, struct FTW *pathinfo) {
     struct procInfo {
         const char *basename;
-        size_t basenameSize;
+        int basenameSize;
         uid_t owner;
     };
 

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 a
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+#define _LARGEFILE64_SOURCE
+#define _FILE_OFFSET_BITS 64
+
+#include <ctype.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <linux/limits.h>
+#include <pwd.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/// Returns systemd real PID.
+pid_t find_systemd(void);
+
+/// Returns 0 when the process PID is ready.
+// TODO
+int wait_on_pid(int PID) { return 0; }
+
+/// Enters in the mount and pid namespaces of the process PID, while preserving PWD.
+/// Returns 0 on success.
+int enter_target_ns(int PID);
+
+/// Stops this process in favor or running it as child.
+void continue_as_child(void);
+
+int main(int argc, char *argv[]) {
+#ifndef NDEBUG
+    printf("Starting nslogin with arguments: ");
+    for (int i = 0; i < argc; i++) {
+        printf("%s ", argv[i]);
+    }
+    putc('\n', stdout);
+    // print euid
+    uid_t uid = getuid();
+    gid_t gid = getgid();
+    printf("euid: %d\n", geteuid());
+    printf("uid: %d\n", getuid());
+#endif
+    // Wait for systemd to be ready
+    pid_t systemdPid = find_systemd();
+    if (systemdPid == 0) {
+        perror("Could not find systemd PID");
+        exit(1);
+    }
+    int systemdStatus;
+    while ((systemdStatus = wait_on_pid(systemdPid))) {
+    }
+
+    // Gain root privilege
+    if (setegid(0) != 0) {
+        perror("setegid as root");
+        exit(2);
+    }
+    if (seteuid(0) != 0) {
+        perror("seteuid as root");
+        exit(3);
+    }
+
+    // Enter systemd namespace
+    if (enter_target_ns(systemdPid) != 0) {
+        perror("Failed to set namespace to systemd's");
+        exit(4);
+    }
+
+    // Drop priviledges back as the current user
+    if (seteuid(uid) != 0) {
+        perror("seteuid back as user");
+        exit(5);
+    }
+    if (setegid(gid) != 0) {
+        perror("setegid back as user");
+        exit(6);
+    }
+
+    // Without forking after setting PID namespace, we get setpgid errors when piping commands.
+    //  child setpgid (PID_X to PID_Y): Operation not permitted
+    continue_as_child();
+    // Having no argument means that we want to shell in.
+    int argvslen = 1;
+    if (argc > 1) {
+        argvslen = argc - 1; // argv[0] is this binary, skip it.
+    }
+    char *argvs[argvslen + 1];
+    argvs[argvslen] = NULL;
+
+    // Entering shell as default behaviour.
+    char *pathname = getenv("SHELL");
+    argvs[0] = pathname;
+
+    // We pointed to a binary to execute instead of entering the default shell.
+    if (argc > 1) {
+        pathname = argv[1]; // executable is passed as first argument
+        for (int i = 1; i < argc; ++i) {
+            argvs[i - 1] = argv[i];
+        }
+    }
+
+    // Make sure any pending output is flushed before replacing this binary image.
+    fflush(stdout);
+    fflush(stderr);
+
+    // Finally exec.
+    if (execvp(pathname, argvs) == -1) {
+        const size_t size = 128;
+        char msg[size];
+        snprintf(msg, size, "Executing \"%s\" failed", pathname);
+        perror(msg);
+        exit(7);
+    }
+} // main.


### PR DESCRIPTION
`nslogin.c` provides a small binary with setuid capabilities to enter systemd namespace. WSL Launcher should use this binary as the entry point if the experimental systemd support is enabled.

There remains one important TODO: go through the PAM stack.