### PR TITLE
Ship nslogin and other scripts built from makefiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,13 @@ export libexecdir = $(exec_prefix)/libexec
 
 .PHONY: install clean
 
+nslogin:
+	$(MAKE) -C ./systemd/nslogin/
+
 
 install:
 	mkdir -p $(DESTDIR)$(libexecdir)
-	$(MAKE) -C ./systemd/nslogin/ install 
+	$(MAKE) -C ./systemd/nslogin/ install
 	$(INSTALL) -o root -m 755 ./wsl-setup $(DESTDIR)$(libexecdir)
 	$(INSTALL) -o root -m 755 ./systemd/wsl-systemd $(DESTDIR)$(libexecdir)
 

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,0 @@
-wsl-setup /usr/libexec
-systemd/wsl-systemd /usr/libexec

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,12 @@
 #!/usr/bin/make -f
 #export DH_VERBOSE = 1
 
+NSLOGINPATH = debian/wsl-setup/usr/libexec/nslogin
+
 %:
 	dh $@
+
+# nslogin needs to be setuid.
+override_dh_fixperms:
+	ls $(NSLOGINPATH)
+	dh_fixperms --exclude $(NSLOGINPATH)

--- a/systemd/nslogin/Makefile
+++ b/systemd/nslogin/Makefile
@@ -23,6 +23,7 @@ Release: nslogin
 
 
 install: Release
+	mkdir -p $(DESTDIR)$(libexecdir)
 	$(INSTALL) -o root -m 6755 ./nslogin $(DESTDIR)$(libexecdir)
 
 


### PR DESCRIPTION
Fix build system.
Adapt debian build to keep permission on nslogin (setuid bits).

Co-authored-by: Carlos Nihelton <carlos.santanadeoliveira@canonical.com>