### PR TITLE
Cleans the in-source tree built binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # GNU Standard says we should not assign DESTDIR, but this minor adjustment is really handy when debugging.
-DESTDIR:=$(shell realpath $(DESTDIR))
+DESTDIR:=$(if $(DESTDIR), $(shell realpath $(DESTDIR)),)
 export INSTALL=install
 
 # Standard GNU Makefile definitions:
@@ -22,7 +22,7 @@ install:
 
 
 clean:
+	$(MAKE) -C ./systemd/nslogin/ clean
 	rm -f $(DESTDIR)$(libexecdir)/wsl-setup
 	rm -f $(DESTDIR)$(libexecdir)/wsl-systemd
-	$(MAKE) -C ./systemd/nslogin/ clean
 

--- a/systemd/nslogin/Makefile
+++ b/systemd/nslogin/Makefile
@@ -1,25 +1,28 @@
 SRC=nslogin.c
 LIBS=-lsystemd
-CFLAGS=-Wall -Wextra -Wconversion -pedantic
-CMODEFLAGS=-O0 -g -DDEBUG
-POSTBUILD=chown root:root $@ && chmod ug+s $@
+CFLAGS=-Wall -Wextra -Wconversion -pedantic -g
+POSTBUILD=chown root:root $< && chmod ug+s $<
 LINTER=clang-tidy-12
+
+
+Release: CMODEFLAGS=-O2 -DNDEBUG
+Release: nslogin
+
+
+Debug: CMODEFLAGS=-O0 -DDEBUG
+Debug: nslogin
+	$(POSTBUILD)
 
 
 nslogin: $(SRC)
 	$(CC) $(CFLAGS) $(CMODEFLAGS) $(SRC) $(LIBS) -o $@
-	$(POSTBUILD)
 
 
 .PHONY: lint install clean
 
 
 lint:
-	$(LINTER) $(SRC) -- $(CFLAGS) $(LIBS) 
-
-
-Release: CMODEFLAGS=-O3 -DNDEBUG
-Release: nslogin
+	$(LINTER) $(SRC) -- $(CFLAGS) $(LIBS)
 
 
 install: Release
@@ -28,5 +31,6 @@ install: Release
 
 
 clean:
+	rm -f ./nslogin
 	rm -f $(DESTDIR)$(libexecdir)/nslogin
 


### PR DESCRIPTION
- All builds failed in LP except AMD64 because the binary was in the source tree.
- That was caused by the clean target only removing the installed copy.

Overhauled the Makefiles to:
- Remove the nuisance of realpath being called with empty args.
- Fix the nslogin clean target.
- Make the nslogin default target be the Release one.

During development or debugging one will have the inconvenience to type `make Debug` to get `DDEBUG` defined. Noticed though that the option `-g` was promoted to `CFLAGS` to preserve the debug symbols in all situations.