### PR TITLE
Fix Coverity warnings and changed enter_target_ns() function to use pidfd_open syscall.

### DIFF
--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -293,7 +293,7 @@ int enter_target_ns(pid_t PID) {
         return -2;
     }
 
-    int nstypes[2] = {CLONE_NEWPID, CLONE_NEWNS};
+    const int nstypes[TARGET_NS_COUNT] = {CLONE_NEWPID, CLONE_NEWNS};
     for (int i = 0; i < TARGET_NS_COUNT; i++) {
         if (setns(pidFd, nstypes[i]) != 0) {
             perror("Failed to set namespace");

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -144,7 +144,7 @@ static bool is_systemd_startup_complete(sd_bus *bus) {
     int busOk = sd_bus_get_property_string(bus, "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
                                            "org.freedesktop.systemd1.Manager", "SystemState", &err, &msg);
     if (busOk < 0) {
-        fprintf(stderr, "Bus error %s", err.message);
+        fprintf(stderr, "Bus error %s\n", err.message);
         return false;
     }
 

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -299,7 +299,7 @@ int enter_target_ns(pid_t PID) {
             return -1;
         }
         int fd = open(nsPath, O_RDONLY);
-        if (fd <= 0) {
+        if (fd < 0) {
             char msg[80];
             snprintf(msg, 80, "Failed to open namespace file descriptor from path %s", nsPath);
             perror(msg);

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -289,7 +289,7 @@ int enter_target_ns(pid_t PID) {
     for (int i = 0; i < TARGET_NS_COUNT; i++) {
         memset(nsPath, 0, MAX_NS_PATH);
         if (snprintf(nsPath, MAX_NS_PATH, "/proc/%d/ns/%s", PID, ns[i].nsname) <= 0) {
-            perror("Faild to format namespace path");
+            perror("Failed to format namespace path");
             return -1;
         }
         int fd = open(nsPath, O_RDONLY);

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -274,7 +274,6 @@ void continue_as_child(void) {
     exit(EXIT_FAILURE);
 }
 
-#define MAX_NS_PATH 25
 #define TARGET_NS_COUNT 2
 // Implements a wrapper around SYS_pidfd_open syscall with flags defaulted to 0.
 int pidfd_open(pid_t PID) { return (int)syscall(SYS_pidfd_open, PID, 0); }

--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -160,7 +160,7 @@ static bool is_systemd_startup_complete(sd_bus *bus) {
 
 /// Returns 0 if the basename of the symlink target matches the expected name up to length.
 static int symlink_basename_cmp(const char *symlink, const char *name, size_t length) {
-    char target[PATH_MAX];
+    char target[PATH_MAX + 1];
     ssize_t len = readlink(symlink, target, PATH_MAX);
     if (len == -1) {
         // This condition becomes really common if attempting to find the PID by trial-and-error.


### PR DESCRIPTION
I gotta confess I liked better the implementation of enter_target_ns() function with the referred system call than by manipulating the `/proc/#/ns/*` paths.

About the possible buffer overruns with readlink() and leaking file descriptors when fd=0, we should be fine now. 