### PR TITLE
Add multiple attempts for detecting systemd

### DIFF
--- a/systemd/nslogin/nslogin.c
+++ b/systemd/nslogin/nslogin.c
@@ -200,6 +200,12 @@ pid_t find_systemd(void) {
 
     struct procInfo systemd = {"systemd", 7, 0};
     char exeLinkPath[EXEPATH_BUFSIZE] = {'\0'};
+    const int loopMax = 3;
+    const unsigned int timeoutUs = 500000;
+
+    // Sometimes we detect systemd is not running, requiring the user to attempt relaunching their
+    // wsl distro, so try to see if we see it after waiting a short ammount of time.
+    for (int waitCounts = 0; waitCounts < loopMax; ++waitCounts) {
     for (int16_t pidCandidate = 2; pidCandidate < INT16_MAX; pidCandidate++) {
         int ok = snprintf(exeLinkPath, EXEPATH_BUFSIZE, "/proc/%" SCNd16 "/exe", pidCandidate);
         if (ok <= 0 || ok >= EXEPATH_BUFSIZE) {
@@ -214,6 +220,9 @@ pid_t find_systemd(void) {
             continue;
         }
         return (pid_t)pidCandidate;
+        }
+
+        usleep(timeoutUs); // 500 ms.
     }
     return 0;
 }


### PR DESCRIPTION
When running in Windows Terminal with:

```cmd
C:\WINDOWS\system32\wsl.exe -d Fedora -e /usr/libexec/nslogin /usr/bin/fish
```

I tend to see:

> ERROR: Systemd is not running. Please terminate this instance by running "wsl -t <distro>" from Windows shell and try again.

I believe there is a slight race condition when checking for a systemd candidate.

This adds multiple checks with a slight timeout before officially declaring systemd is not running.