### PR TITLE
fix: Prevents creating an unexpected user

### DIFF
--- a/cloud/cloud.cfg.d/99_wsl.cfg
+++ b/cloud/cloud.cfg.d/99_wsl.cfg
@@ -1,4 +1,8 @@
 datasource_list: [WSL, None]
 network:
   config: disabled
-
+# Prevents creation of an unexpected user
+# See: https://github.com/ubuntu/WSL/issues/468
+system_info:
+  distro: ubuntu
+  default_user:

--- a/cloud/cloud.cfg.d/99_wsl.cfg
+++ b/cloud/cloud.cfg.d/99_wsl.cfg
@@ -2,6 +2,10 @@ datasource_list: [WSL, None]
 network:
   config: disabled
 # Prevents creation of an unexpected user
+# The redundant "distro" subkey is necessary in order to match exactly what is in
+# `/etc/cloud/cloud.cfg`, omitting it would result in the default user still being created
+# as this would be a "generic" `system_info` while the one in `/etc/cloud/cloud.cfg` would be
+# the Ubuntu specific.
 # See: https://github.com/ubuntu/WSL/issues/468
 system_info:
   distro: ubuntu


### PR DESCRIPTION
`/etc/cloud/cloud.cfg` sets the default user "ubuntu" for any instance of the Ubuntu distro. Changing that is outside of our scope, as it would affect other platforms.
Instead we override that key with nothing to prevent creating any default user at all. User creation must be explicitely specified by user-data.

Starting an instance without this change (you'll see the "ubuntu" account UID 1000):
![image](https://github.com/ubuntu/wsl-setup/assets/11138291/4630531e-bce1-4740-a737-1d8df04d2212)


Starting an instance with this change already seeded (o UID 1000 in /etc/passwd, /home is empty):
![Captura de tela 2024-05-02 105742](https://github.com/ubuntu/wsl-setup/assets/11138291/ad1c151a-e960-434a-833c-1d80b37d269f)


Fixes: https://github.com/ubuntu/WSL/issues/468
Closes: UDENG-2748