### PR TITLE
fix(cloud-init): DS List should contain one additional datasource in …

### DIFF
--- a/cloud/cloud.cfg.d/99_wsl.cfg
+++ b/cloud/cloud.cfg.d/99_wsl.cfg
@@ -1,4 +1,4 @@
-datasource_list: [WSL, None]
+datasource_list: [WSL, NoCloud]
 network:
   config: disabled
 # Prevents creation of an unexpected user


### PR DESCRIPTION
…order to skip running cloud-init when there is no user-data file

Somehow we didn't notice this mistake, but the spec WS028 contains a discussion about why we should have two actual datasources in this list, being one WSL ofc.

Having `datasources_list: [WSL, None]` is the same as having `datasources_list: [WSL]`: `ds-identify` won't run but rather pick the WSL datasource and run cloud-init with that, resulting in inneficiency and minor UX issue with the latest changes in the distro launcher, as depicted below.

```
Installing, this may take a few minutes...
Checking for initialization tasks...

.....
status: done
WARNING: initialization tasks partially succeeded, see below:
status: done
extended_status: degraded done
boot_status_code: enabled-by-generator
last_update: Thu, 01 Jan 1970 01:29:19 +0000
detail: DataSourceNone
errors: []
recoverable_errors:
WARNING:
        - Used fallback datasource
```

The spec suggested adding `NoCloud` instead, but somehow `None` landed here instead and I only noticed after playing with the new launcher for a while.

What we want to see when there is no applicable cloud-config data is (cloud-init goes disabled):

```
Installing, this may take a few minutes...
Checking for initialization tasks...


status: disabled
ERROR: no candidate default user was found

Please create a default UNIX user account. The username does not need to match your Windows username.
For more information visit: https://aka.ms/wslusers
Enter new UNIX username:
```

(maye the `ERROR: no candidate default user was found` should be "INFO" instead or maybe print nothing related to cloud-init in case it's disabled, but that's another topic).