### PR TITLE
feat: Delivery of warnings via MotD if cloud-init doesn't succeed

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,3 @@
 systemd/ lib/
 cloud/ etc/
+update-motd.d/ etc/

--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,3 @@
 systemd/ lib/
 cloud/ etc/
-update-motd.d/ etc/
+update-motd.d/99-wsl etc/update-motd.d/

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,3 @@
 %:
 	dh $@
 
-execute_after_dh_fixperms:
-	chmod 0755 update-motd.d/99-cloud-init-warning

--- a/debian/rules
+++ b/debian/rules
@@ -3,3 +3,6 @@
 
 %:
 	dh $@
+
+execute_after_dh_fixperms:
+	chmod 0755 update-motd.d/99-cloud-init-warning

--- a/update-motd.d/99-cloud-init-warning
+++ b/update-motd.d/99-cloud-init-warning
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Warns if cloud-init didn't fully succeed during initialization of this instance.
+
+stampfile="$HOME/.skip-cloud-init-warning"
+
+[ -f "$stampfile" ] && exit 0
+
+if grep -q "ERROR\|WARNING" /var/log/cloud-init.log; then
+  echo 'Something went wrong during initialization of this distro.'
+  echo 'To know more run "cloud-init status --long" or read the log at /var/log/cloud-init.log.'
+  touch "$stampfile"
+fi

--- a/update-motd.d/99-wsl
+++ b/update-motd.d/99-wsl
@@ -1,8 +1,10 @@
 #!/bin/sh
 # Warns if cloud-init didn't fully succeed during initialization of this instance.
+set -e
 
 stampfile="$HOME/.skip-cloud-init-warning"
 
+[ "$(systemd-detect-virt)" != "wsl" ] && exit 0
 [ -f "$stampfile" ] && exit 0
 
 if grep -q "ERROR\|WARNING" /var/log/cloud-init.log; then

--- a/update-motd.d/99-wsl
+++ b/update-motd.d/99-wsl
@@ -5,10 +5,14 @@ set -e
 stampfile="$HOME/.skip-cloud-init-warning"
 
 [ "$(systemd-detect-virt)" != "wsl" ] && exit 0
+
+cloudinitlog="/var/log/cloud-init.log"
+[ ! -f "$cloudinitlog" ] && exit 0
+
 [ -f "$stampfile" ] && exit 0
 
-if grep -q "ERROR\|WARNING" /var/log/cloud-init.log; then
+if grep -q "ERROR\|WARNING" "$cloudinitlog"; then
   echo 'Something went wrong during initialization of this distro.'
-  echo 'To know more run "cloud-init status --long" or read the log at /var/log/cloud-init.log.'
+  echo "To know more run \"cloud-init status --long\" or read the log at $cloudinitlog."
   touch "$stampfile"
 fi


### PR DESCRIPTION
I started this in the launcher, but @jibel correctly suggested this would be a better place to put this script.

Once deployed, if the stamp file doesn't exist in the current user's home directory, a warning message is shown if cloud-init log contains ERROR or WARNING messages, what matches the semantics of cloud-init extended status as we observed recently: a call to `LOG.error` or `LOG.warning` automatically sets its extended status to degraded even if it "completely succeeds" applying the existing configuration.

![image](https://github.com/user-attachments/assets/22ec7a95-eee1-4b4e-8d38-ad7063ee0e0d)
