### PR TITLE
fix: Check if cloud-init log is readable by the current user in 99-wsl

### DIFF
--- a/update-motd.d/99-wsl
+++ b/update-motd.d/99-wsl
@@ -7,7 +7,7 @@ stampfile="$HOME/.skip-cloud-init-warning"
 [ "$(systemd-detect-virt)" != "wsl" ] && exit 0
 
 cloudinitlog="/var/log/cloud-init.log"
-[ ! -f "$cloudinitlog" ] && exit 0
+[ ! -r "$cloudinitlog" ] && exit 0
 
 [ -f "$stampfile" ] && exit 0
 


### PR DESCRIPTION
If the user is not member of the `adm` group this script fails with "access denied". Thus we should check if the log is readable by the current user instead of just checking if it exists.