### PR TITLE
Only wait on cloud init when it will run

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Depends: adduser,
          fonts-ubuntu,
          gawk,
          passwd,
+         systemd,
          ${shlibs:Depends},
          ${misc:Depends},
 Description: ${source:Synopsis}

--- a/wsl-setup
+++ b/wsl-setup
@@ -87,8 +87,10 @@ if [ -n "${local_app_data}" ]; then
   cp "/usr/share/fonts/truetype/ubuntu/UbuntuMono[wght].ttf" "${fonts_dir}"
 fi
 
-# Wait for cloud-init to finish.
-cloud-init status --wait > /dev/null 2>&1 || true
+# Wait for cloud-init to finish if systemd and its service is enabled.
+if status=$(LANG=C systemctl is-system-running 2>/dev/null) || [ "${status}" != "offline" ] && systemctl is-enabled --quiet cloud-init.service 2>/dev/null; then
+  cloud-init status --wait > /dev/null 2>&1 || true
+fi
 
 # Check if there is a pre-provisioned users (pre-baked on the rootfs or created by cloud-init).
 user_id=$(get_first_interactive_uid)


### PR DESCRIPTION
Ensure the unit is enabled under a systemd enabled distribution. This will also make it compatible with WSL1.