### PR TITLE
Ship wsl-setup under /usr/lib/wsl/ instead of libexec

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,5 +1,5 @@
 cloud/ etc/
 update-motd.d/99-wsl etc/update-motd.d/
 systemd/ lib/
-wsl-setup usr/libexec/
+wsl-setup usr/lib/wsl/
 wsl/ usr/share/


### PR DESCRIPTION
This is fixing Microsoft's checker warning.

UDENG-5783