### PR TITLE
Using WSL_DISTRO_NAME instead of the wslpath technique

### DIFF
--- a/wsl-setup
+++ b/wsl-setup
@@ -99,7 +99,7 @@ function install_ubuntu_font() {
 }
 
 
-echo "Provisioning the new WSL instance $(wslpath -am / | cut -d '/' -f 4)"
+echo "Provisioning the new WSL instance $WSL_DISTRO_NAME"
 echo "This might take a while..."
 
 # Read the Windows user name.


### PR DESCRIPTION
As recommended by the MS WSL Team.

I confirmed this and other interesting WSL_* environment variables are available for this script.
I wish systemd services had the same.

![image](https://github.com/user-attachments/assets/ef423d56-817f-483f-b34a-46768163e8ed)


---
UDENG-6170