### PR TITLE
Remove the systemd-binfmt override

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+wsl-setup (0.5.10) questing; urgency=medium
+
+  * Fix Ubuntu on WSL install fails on non-ASCII usernames (LP: #2118617)
+  * Remove systemd-binfmt.service overrides
+
+ -- Carlos Nihelton <cnihelton@ubuntu.com>  Thu, 24 Jul 2025 18:14:54 -0300
+
+wsl-setup (0.5.9) plucky; urgency=medium
+
+  * Fix dependency on cloud-init.service: (LP: #2104307)
+    - The wsl-setup script was supposed to sync with cloud-init
+    - It checked if the cloud-init.service was enabled.
+    - That unit no longer exists on Plucky.
+    - It now checks for cloud-init-local.service, which exists
+      on plucky and prior releases as well.
+
+ -- Carlos Nihelton <cnihelton@ubuntu.com>  Thu, 27 Mar 2025 10:22:28 -0300
+
 wsl-setup (0.5.8) plucky; urgency=medium
 
   * Ship wsl-setup under /usr/lib/wsl/ instead of libexec:

--- a/systemd/system/systemd-binfmt.service.d/wsl.conf
+++ b/systemd/system/systemd-binfmt.service.d/wsl.conf
@@ -1,4 +1,0 @@
-# systemd breaks WSL interoperability by rewriting the binfmt interpreters configuration.
-
-[Unit]
-ConditionVirtualization=!wsl


### PR DESCRIPTION
Since WSL 2.5.7 we have a systemd generator that protects interop by regenerating the WSL binfmt entry.
Thus, services like systemd-binfmt are no longer a concern.

Users on older versions of WSL should rely on docs while those on the latest stable should find the expected behaviour by default.

As a precaution I confirmed locally that dpkg indeed removes the file upon upgrade.

Closes #11

---
UDENG-6126