### PR TITLE
fix: Case-fold the Windows  username before sanitization

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wsl-setup (0.5.11) questing; urgency=medium
+
+  * Case-fold the Windows username before sanitization (LP: #2122047)
+
+ -- Carlos Nihelton <cnihelton@ubuntu.com>  Thu, 04 Sep 2025 11:08:42 -0300
+
 wsl-setup (0.5.10) questing; urgency=medium
 
   * Fix Ubuntu on WSL install fails on non-ASCII usernames (LP: #2118617)

--- a/wsl-setup
+++ b/wsl-setup
@@ -118,7 +118,7 @@ echo "Provisioning the new WSL instance $WSL_DISTRO_NAME"
 echo "This might take a while..."
 
 # Read the Windows user name.
-win_username=$(powershell_env "UserName")
+win_username=$(powershell_env "UserName.ToLower()")
 # replace any potential whitespaces with underscores.
 win_username="${win_username// /_}"
 


### PR DESCRIPTION
The `wsl-setup` script reads the Windows user name and sanitizes it,
dropping invalid characters for a Linux user name, including ASCII upper
case letters. We could case fold the username first and then drop the
invalid ones, making it a bit less surprising. That would still have
some nasty cases we cannot handle in a smart way, like `MartínJoão` being
converted into `martnjoo` but that’s why we prompt for the username, to
let users edit that before actual submission.

While case folding can be done with  `tr "[:upper:]" "[:lower:]"` or even
better `awk '{print tolower(0)}'` (awk handles Unicode better), better yet
is to leverage PowerShell because then we're guaranteed to respect the
Windows user locale (a WSL instance could be set up with a different
locale and the case-folding results couldn't match the user's
expectation).

To illustrate how this works:

```bash
j@DESKTOP-551PQ9O:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.6 LTS
Release:        20.04
Codename:       focal

j@DESKTOP-551PQ9O:~$ powershell.exe -Command '$Env:Username'
João

j@DESKTOP-551PQ9O:~$ var="Username"; powershell.exe -NoProfile -Command '& {
[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
$Env:'"${var}"'}'
João

j@DESKTOP-551PQ9O:~$ var="Username.ToLower()"; powershell.exe -NoProfile -Command '& {
[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
$Env:'"${var}"'}'
joão

```

In the example above the username would be sanitized to: `oo`
but with the changes it would at least be: `joo`
(the 'ã' is still dropped, but it's much easier to add it).

The motivation for this change came from a user named `AdminUser`.
That would originally be sanitized to: `dminser`
but now it becomes: `adminuser`

One must remember that in the end this name is just a suggestion
prefilling a read input. User is free to edit it before hitting enter
and submitting the username to the `adduser` program.

---

UDENG-7489
