### PR TITLE
feat: Adds an integration test workflow

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -175,6 +175,7 @@ jobs:
             source test/integration-test.sh
 
       - name: "Clean up" # Probably not necessary since we're leveraging ephemeral GH's runners.
+        if: always()
         shell: powershell
         run: |
           wsl --unregister ${{ env.instance }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,6 +2,8 @@ name: Integration tests
 on:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "4 3 * * 2" # Tuesdays 03:04 am.
   push:
     branches: ["main"]
 env:
@@ -12,6 +14,7 @@ env:
   instance: Ubuntu-${{ github.run_id }}
   profile_script: /etc/profile.d/99-quit-wsl.sh
   instance_working_dir: ~/wsl-setup-${{ github.run_id }}
+
 jobs:
   build-deb:
     name: Build wsl-setup debian package
@@ -24,6 +27,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker-image: ubuntu:devel
+
   cache-img:
     name: Cache the daily-live image
     runs-on: ubuntu-latest
@@ -51,6 +55,7 @@ jobs:
               exit 2
           fi
           echo "cache-key=$key" >> "$GITHUB_OUTPUT"
+
       - name: Check image cache first
         id: cache
         uses: actions/cache@v4
@@ -58,6 +63,7 @@ jobs:
           path: ${{ env.images_dir }}
           key: ${{ steps.compute-cache-key.outputs.cache-key }}
           enableCrossOsArchive: true
+
       - name: Download a daily-live image
         if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
@@ -70,6 +76,7 @@ jobs:
           echo "::error:: Failed to download the image from ${{ env.base_url }}/${{ env.image_name }}'."
               exit 1
           fi
+
   test-wsl-setup:
     needs: [build-deb, cache-img]
     name: "Integration tests"
@@ -81,6 +88,7 @@ jobs:
           path: ci-artifacts
           # name: is left blank so that all artifacts are downloaded, thus we don't couple on
           # whatever name was chosen in the build-debian action.
+
       - name: Fetch the image from cache
         id: cache
         uses: actions/cache@v4
@@ -90,6 +98,7 @@ jobs:
           restore-keys: |
             ${{ needs.cache-img.outputs.cache-key }}
           enableCrossOsArchive: true
+
       - name: "Set up a WSL instance from the daily image"
         shell: powershell
         env:
@@ -134,6 +143,7 @@ jobs:
           [System.IO.File]::WriteAllLines($filePath, $env:cloudinit, $utf8NoBomEncoding)
           Write-Output "Testing wsl-setup with cloud-init user data at ${cloudinitdir} :"
           Get-Content "${cloudinitdir}\${{ env.instance }}.user-data"
+
       - name: Test initial setup
         timeout-minutes: 10
         shell: powershell
@@ -150,10 +160,12 @@ jobs:
           wsl -d "${{ env.instance }}" -u root -- bash -ec "rm ${{ env.profile_script }} || true"
           wsl -d "${{ env.instance }}" -u root -- bash -ec "cat /var/log/cloud-init.log || true"
           wsl --terminate ${{ env.instance }}
+
       - uses: ubuntu/WSL/.github/actions/wsl-checkout@main
         with:
           distro: ${{ env.instance }}
           working-dir: ${{ env.instance_working_dir }}
+
       - name: Assertions on the new instance
         uses: ubuntu/WSL/.github/actions/wsl-bash@main
         with:
@@ -161,6 +173,7 @@ jobs:
           working-dir: ${{ env.instance_working_dir }}
           exec: |
             source test/integration-test.sh
+
       - name: "Clean up" # Probably not necessary since we're leveraging ephemeral GH's runners.
         shell: powershell
         run: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,210 @@
+name: Integration tests
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+env:
+  # TODO: Transform this into a matrix
+  base_url: https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/current
+  image_name: questing-wsl-amd64.wsl
+  images_dir: images
+  instance: Ubuntu-${{ github.run_id }}
+  profile_script: /etc/profile.d/99-quit-wsl.sh
+jobs:
+  build-deb:
+    name: Build wsl-setup debian package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+      - name: Build deb
+        uses: canonical/desktop-engineering/gh-actions/common/build-debian@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          docker-image: ubuntu:devel
+  cache-img:
+    name: Cache the daily-live image
+    runs-on: ubuntu-latest
+    outputs:
+      cache-key: ${{ steps.compute-cache-key.outputs.cache-key }}
+    steps:
+      - name: Compute image cache key
+        id: compute-cache-key
+        shell: bash
+        run: |
+          set -eu
+
+          shafile="SHA256SUMS"
+          uri="${{ env.base_url }}/${shafile}"
+          curl -o "$shafile" "${uri}"
+          if [ $? -ne 0 ]; then
+          echo "::error:: Failed to download the checksum file from $uri."
+              exit 1
+          fi
+
+          # If a line matches, then awk extracts the first field: the checksum.
+          key=$(grep -E "^[a-f0-9]+ \*${{ env.image_name }}$" "$shafile" | awk '{print $1}')
+          if [ -z "$key" ]; then
+          echo "::error:: Checksum for '${{ env.image_name }}' not found in the $shafile file."
+              exit 2
+          fi
+          echo "cache-key=$key" >> "$GITHUB_OUTPUT"
+      - name: Check image cache first
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.images_dir }}
+          key: ${{ steps.compute-cache-key.outputs.cache-key }}
+          enableCrossOsArchive: true
+      - name: Download a daily-live image
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -eu
+
+          mkdir -p "${{ env.images_dir }}"
+          curl -o "${{ env.images_dir }}/${{ env.image_name }}" "${{ env.base_url }}/${{ env.image_name }}"
+          if [ $? -ne 0 ]; then
+          echo "::error:: Failed to download the image from ${{ env.base_url }}/${{ env.image_name }}'."
+              exit 1
+          fi
+  test-wsl-setup:
+    needs: [build-deb, cache-img]
+    name: "Integration tests"
+    runs-on: windows-2025 # WSL and winget are preinstalled and working
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: ci-artifacts
+          # name: is left blank so that all artifacts are downloaded, thus we don't couple on
+          # whatever name was chosen in the build-debian action.
+      - name: Fetch the image from cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.images_dir }}
+          key: ${{ needs.cache-img.outputs.cache-key }}
+          restore-keys: |
+            ${{ needs.cache-img.outputs.cache-key }}
+          enableCrossOsArchive: true
+      - name: "Set up a WSL instance from the daily image"
+        shell: powershell
+        env:
+          WSL_UTF8: "1" # Recommended otherwise it's hard to read wsl output on Github
+          # Just to skip the interactive session
+          cloudinit: |
+            #cloud-config
+            users:
+            - name: u
+              gecos: Ubuntu User
+              groups: [adm,dialout,cdrom,floppy,sudo,audio,dip,video,plugdev,netdev]
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              shell: /bin/bash
+            write_files:
+            - path: /etc/wsl.conf
+              append: true
+              content: |
+                [user]
+                default=u
+            packages: [hello]
+        run: |
+          # No launch so we can install the deb before running the OOBE
+          wsl --install --no-launch --from-file "./${{ env.images_dir }}/${{ env.image_name }}" --name "${{ env.instance }}"
+          wsl -d "${{ env.instance }}" -u root -- ls -l "./ci-artifacts/wsl-setup_*/"
+          wsl -d "${{ env.instance }}" -u root -- dpkg -i "./ci-artifacts/wsl-setup_*/wsl-setup_*.deb"
+
+          # In case cloud-init fails we don't get stuck on endless prompting.
+          wsl -d "${{ env.instance }}" -u root -- adduser --quiet --gecos '' --disabled-password ubuntu
+          wsl -d "${{ env.instance }}" -u root -- usermod ubuntu -aG "adm,cdrom,sudo,dip,plugdev"
+          wsl -d "${{ env.instance }}" -u root -- cloud-init status --wait
+          wsl -d "${{ env.instance }}" -u root -- bash -ec "rm /etc/cloud/cloud-init.disabled || true"
+          wsl -d "${{ env.instance }}" -u root -- bash -ec 'printf "#!/bin/bash\necho Exiting because the profile says so\nexit 0\n" > ${{ env.profile_script }}'
+          wsl -d "${{ env.instance }}" -u root -- chmod '0777' ${{ env.profile_script }}
+          wsl -d "${{ env.instance }}" -u root -- cloud-init clean --logs
+          wsl --shutdown
+
+          # Write the cloud-init user-data contents.
+          $cloudinitdir = New-Item -ItemType "Directory" -Path "${env:UserProfile}\.cloud-init\" -Force
+          # TODO: Investigate why UTF-8 BOM seems to break cloud-init.
+          $filePath="${cloudinitdir}\${{ env.instance }}.user-data"
+          $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+          [System.IO.File]::WriteAllLines($filePath, $env:cloudinit, $utf8NoBomEncoding)
+          Write-Output "Testing wsl-setup with cloud-init user data at ${cloudinitdir} :"
+          Get-Content "${cloudinitdir}\${{ env.instance }}.user-data"
+      - name: Test initial setup
+        timeout-minutes: 10
+        shell: powershell
+        run: |
+          wsl -d "${{ env.instance }}" # Will run the wsl-setup script.
+          if (!(Test-Path -Path "${env:LocalAppData}\Microsoft\Windows\Fonts\Ubuntu*.ttf")) {
+            Write-Error "Ubuntu font was not installed as expected"
+            Exit 1
+          }
+          if (!(Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Fonts\" -Name "Ubuntu*" )) {
+            Write-Error "Ubuntu font was not registered"
+            Exit 2
+          }
+          wsl -d "${{ env.instance }}" -u root -- bash -ec "rm ${{ env.profile_script }} || true"
+          wsl -d "${{ env.instance }}" -u root -- bash -ec "cat /var/log/cloud-init.log || true"
+          wsl --terminate ${{ env.instance }}
+      - name: Assertions on the new instance
+        uses: ubuntu/WSL/.github/actions/wsl-bash@main
+        with:
+          distro: ${{ env.instance }}
+          working-dir: "~/"
+          exec: |
+            if [[ ! -r /usr/lib/wsl/ubuntu.ico ]]; then
+              echo "::error:: Missing Ubuntu icon in the /usr/share/wsl/ directory"
+              ls /usr/share/wsl/
+              exit 1
+            fi
+
+            if [[ ! -r /usr/lib/wsl/terminal-profile.json ]]; then
+              echo "::error:: Missing terminal profile fragment in the /usr/share/wsl/ directory"
+              ls /usr/share/wsl/
+              exit 2
+            fi
+
+            if [[ $(id -u) == 0 ]]; then
+              echo "::error:: Default user shouldn't be root"
+              exit 3
+            fi
+
+            if [[ $(whoami) != "u" ]]; then
+              echo "::error:: Default user doesn't match cloud-init's user-data."
+              exit 4
+            fi
+
+            if [[ $(LANG=C systemctl is-system-running) != "running" ]]; then
+               systemctl --failed
+               exit 5
+            fi
+
+            if [[ $(LANG=C systemctl is-active multipathd.service) != "inactive" ]]; then
+              echo "::error:: Unit multipathd.service should have been disabled by the multipathd.service.d/container.conf override"
+              systemctl status multipathd.service
+              exit 6
+            fi
+
+            if [[ $(systemctl is-active systemd-timesyncd.service) != "active" ]]; then
+              echo "::error:: Unit systemd-timesyncd.service should be enabled in WSL via systemd-timesyncd.service.d/wsl.conf override"
+              systemctl status systemd-timesyncd.service
+              exit 7
+            fi
+
+            if [[ ! -r "/etc/cloud/cloud-init.disabled" ]]; then
+              echo "::error:: Missing cloud-init.disabled marker file"
+              exit 7
+            fi
+
+            hello
+            if [[ $? != 0 ]]; then
+              echo "::error:: Failed to execute the hello program that should have been installed by cloud-init"
+              exit 8
+            fi
+      - name: "Clean up" # Probably not necessary since we're leveraging ephemeral GH's runners.
+        shell: powershell
+        run: |
+          wsl --unregister ${{ env.instance }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,6 +11,7 @@ env:
   images_dir: images
   instance: Ubuntu-${{ github.run_id }}
   profile_script: /etc/profile.d/99-quit-wsl.sh
+  instance_working_dir: ~/wsl-setup-${{ github.run_id }}
 jobs:
   build-deb:
     name: Build wsl-setup debian package
@@ -149,61 +150,17 @@ jobs:
           wsl -d "${{ env.instance }}" -u root -- bash -ec "rm ${{ env.profile_script }} || true"
           wsl -d "${{ env.instance }}" -u root -- bash -ec "cat /var/log/cloud-init.log || true"
           wsl --terminate ${{ env.instance }}
+      - uses: ubuntu/WSL/.github/actions/wsl-checkout@main
+        with:
+          distro: ${{ env.instance }}
+          working-dir: ${{ env.instance_working_dir }}
       - name: Assertions on the new instance
         uses: ubuntu/WSL/.github/actions/wsl-bash@main
         with:
           distro: ${{ env.instance }}
-          working-dir: "~/"
+          working-dir: ${{ env.instance_working_dir }}
           exec: |
-            if [[ ! -r /usr/lib/wsl/ubuntu.ico ]]; then
-              echo "::error:: Missing Ubuntu icon in the /usr/share/wsl/ directory"
-              ls /usr/share/wsl/
-              exit 1
-            fi
-
-            if [[ ! -r /usr/lib/wsl/terminal-profile.json ]]; then
-              echo "::error:: Missing terminal profile fragment in the /usr/share/wsl/ directory"
-              ls /usr/share/wsl/
-              exit 2
-            fi
-
-            if [[ $(id -u) == 0 ]]; then
-              echo "::error:: Default user shouldn't be root"
-              exit 3
-            fi
-
-            if [[ $(whoami) != "u" ]]; then
-              echo "::error:: Default user doesn't match cloud-init's user-data."
-              exit 4
-            fi
-
-            if [[ $(LANG=C systemctl is-system-running) != "running" ]]; then
-               systemctl --failed
-               exit 5
-            fi
-
-            if [[ $(LANG=C systemctl is-active multipathd.service) != "inactive" ]]; then
-              echo "::error:: Unit multipathd.service should have been disabled by the multipathd.service.d/container.conf override"
-              systemctl status multipathd.service
-              exit 6
-            fi
-
-            if [[ $(systemctl is-active systemd-timesyncd.service) != "active" ]]; then
-              echo "::error:: Unit systemd-timesyncd.service should be enabled in WSL via systemd-timesyncd.service.d/wsl.conf override"
-              systemctl status systemd-timesyncd.service
-              exit 7
-            fi
-
-            if [[ ! -r "/etc/cloud/cloud-init.disabled" ]]; then
-              echo "::error:: Missing cloud-init.disabled marker file"
-              exit 7
-            fi
-
-            hello
-            if [[ $? != 0 ]]; then
-              echo "::error:: Failed to execute the hello program that should have been installed by cloud-init"
-              exit 8
-            fi
+            source test/integration-test.sh
       - name: "Clean up" # Probably not necessary since we're leveraging ephemeral GH's runners.
         shell: powershell
         run: |

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -1,0 +1,58 @@
+#/bin/bash
+# This should run inside a WSL instance or machine prepared for testing purposes.
+# It requires installing the wsl-setup Debian package to assert on their results.
+brandingdir="/usr/share/wsl"
+if [[ ! -r "${brandingdir}/ubuntu.ico" ]]; then
+  echo "::error:: Missing Ubuntu icon in the $brandingdir directory."
+  ls "${brandingdir}"
+  exit 1
+fi
+
+if [[ ! -r "${brandingdir}/terminal-profile.json" ]]; then
+  echo "::error:: Missing terminal profile fragment in the $brandingdir directory."
+  ls "${brandingdir}"
+  exit 2
+fi
+
+if [[ $(id -u) == 0 ]]; then
+  echo "::error:: Default user shouldn't be root"
+  exit 3
+fi
+
+if [[ $(whoami) != "u" ]]; then
+  echo "::error:: Default user doesn't match cloud-init's user-data."
+  exit 4
+fi
+
+if [[ $(LANG=C systemctl is-system-running) != "running" ]]; then
+   systemctl --failed
+   exit 5
+fi
+
+if [[ $(LANG=C systemctl is-active multipathd.service) != "inactive" ]]; then
+  echo "::error:: Unit multipathd.service should have been disabled by the multipathd.service.d/container.conf override"
+  systemctl status multipathd.service
+  exit 6
+fi
+
+for unit in "systemd-timesyncd.service" "chrony.service"; do
+  systemctl is-enabled "${unit}"
+  if [[ $? == 0 ]]; then
+    if [[ $(LANG=C systemctl is-active "${unit}" ) != "active" ]]; then
+      echo "::error:: Unit ${unit} should be enabled in WSL via ${unit}.d/wsl.conf override"
+      systemctl status ${unit}
+      exit 7
+    fi
+  fi
+done
+
+if [[ ! -r "/etc/cloud/cloud-init.disabled" ]]; then
+  echo "::error:: Missing cloud-init.disabled marker file"
+  exit 7
+fi
+
+hello
+if [[ $? != 0 ]]; then
+  echo "::error:: Failed to execute the hello program that should have been installed by cloud-init"
+  exit 8
+fi

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 # This should run inside a WSL instance or machine prepared for testing purposes.
 # It requires installing the wsl-setup Debian package to assert on their results.
 brandingdir="/usr/share/wsl"
@@ -35,24 +35,22 @@ if [[ $(LANG=C systemctl is-active multipathd.service) != "inactive" ]]; then
   exit 6
 fi
 
-for unit in "systemd-timesyncd.service" "chrony.service"; do
-  systemctl is-enabled "${unit}"
-  if [[ $? == 0 ]]; then
-    if [[ $(LANG=C systemctl is-active "${unit}" ) != "active" ]]; then
-      echo "::error:: Unit ${unit} should be enabled in WSL via ${unit}.d/wsl.conf override"
-      systemctl status ${unit}
-      exit 7
-    fi
+# Let's not worry about chrony just yet.
+nts_unit="systemd-timesyncd.service"
+if systemctl is-enabled "${nts_unit}"; then
+  if [[ $(LANG=C systemctl is-active "${nts_unit}" ) != "active" ]]; then
+    echo "::error:: Unit ${nts_unit} should be enabled in WSL via ${nts_unit}.d/wsl.conf override"
+    systemctl status ${nts_unit}
+    exit 7
   fi
-done
+fi
 
 if [[ ! -r "/etc/cloud/cloud-init.disabled" ]]; then
   echo "::error:: Missing cloud-init.disabled marker file"
-  exit 7
+  exit 8
 fi
 
-hello
-if [[ $? != 0 ]]; then
+if ! hello; then
   echo "::error:: Failed to execute the hello program that should have been installed by cloud-init"
-  exit 8
+  exit 9
 fi


### PR DESCRIPTION
Looks like we can go quite far with GitHub hosted runners these days (since they made large runners generally available).

I devised an integration test workflow for `wsl-setup` that:
- Downloads and caches the daily-live/current image from cdimages.ubuntu.com
- In parallel, it builds the wsl-setup debian package from git
- When above are done:
  * sets up a WSL instance,
  * installs the deb built by CI, 
  * clean up cloud-init state, 
  * writes some cloud-init user data, 
  * does some actions to prevent the test from being stuck in case cloud-init fails, 
  * runs the initial setup via WSL itself (with just `wsl -d DISTRO`) and 
  * runs some assertions based on the results of having wsl-setup installed.
  
To support development time, part of the assertions are placed in a separate shell script that we can run inside a VM, LXD container or WSL instance at development time (though some can only pass on WSL), assertions which are really coupled to the contents of the package, thus we should pay attention to them when changing the package. Unfortunately I'm not bold enough to put those assertions in an override_build step of debian/rules because I that could result in unnecessary breakages.

My image caching system saves more bandwidth than time. I was pleased to see that CI was taking less than 30s to download a WSL image (building the deb takes much longer, there's probably some caching opportunity in the callee side?). The cache key is the image checksum read from the SHA256SUMS file hosted aside from the image. I had to learn a few tricks to make the cache working cross OSes.

The WSL instance is created from the cached image with `wsl --install --from-file ... --no-launch ...` so we can further customise it with other `wsl -d DISTRO -- <COMMANDS>` without those counting as if the OOBE script was run, that is, WSL keeps track of that instance as still non-initialized.

This whole scheme allows us to:
- claim that the package builds both source and binary outputs
- claim that the installed package behaves as expected on a target
- smoke test the latest images, preventing late breakages if breaking changes appear in them without us noticing.

---

UDENG-7866