### PR TITLE
fix: Enable chrony on WSL

### DIFF
--- a/systemd/system/chrony.service.d/wsl.conf
+++ b/systemd/system/chrony.service.d/wsl.conf
@@ -1,0 +1,7 @@
+# Enable chrony on WSL machines
+# so WSL clock is synced on resume from suspend of the host.
+
+[Unit]
+ConditionVirtualization=
+ConditionVirtualization=|!container
+ConditionVirtualization=|wsl


### PR DESCRIPTION
Since questing we no longer have systemd-timesyncd.service, but chrony.service instead.

But it comes disabled by default because a WSL instance is basically a container instance.

```
ubuntu@DESKTOP-551PQ9O:/mnt/c/Users/User$ systemctl status chrony
○ chrony.service - chrony, an NTP client/server
     Loaded: loaded (/usr/lib/systemd/system/chrony.service; enabled; preset: enabled)
     Active: inactive (dead)
  Condition: start condition unmet at Fri 2025-09-05 16:06:48 -03; 26min ago
             └─ ConditionVirtualization=!container was not met
       Docs: man:chronyd(8)
             man:chronyc(1)
             man:chrony.conf(5)

Sep 05 16:06:19 DESKTOP-551PQ9O systemd[1]: chrony.service - chrony, an NTP client/server was skipped because of an unmet condition check (ConditionVirtualization=!container).
Sep 05 16:06:48 DESKTOP-551PQ9O systemd[1]: chrony.service - chrony, an NTP client/server was skipped because of an unmet condition check (ConditionVirtualization=!container).
ubuntu@DESKTOP-551PQ9O:/mnt/c/Users/User$
```

I can think of three ways to fix this:

1. Rename the `systemd-timesyncd.service.d` directory in this source tree into `chrony.service.d` (plus any minor corrections needed)

2. Ship overrides for both `systemd-timesyncd` and `chrony`

3. Write the override file at install time via a postinst hook, introspecting the system to determine which service is present.

None of the options please me for the following reasons:

1. This breaks older releases. A future SRU targetting plucky and before needs to have this patch undone if taken from main. Alternatively we could branch off, but thats add maintenance costs.

2. Ships unnecessary stuff. A system will either have chrony or systemd-timesyncd but not both.

3. Adds complexity. One of the main reasons why I don't quite like resorting to postinst hooks is that we take to ourselves the burden of keeping track of which files need to be deleted by a postrm hook, job that should otherwise belong to the package manager.

I prefer option 2. It not only seems the least worse of the three options, but in the long term it looks like option 1 being applied in two steps. We ship now both overrides and in a future where systemd-timesyncd is no longer relevant we remove the matching directory, effectively becoming a rename if integrated over time ;p

$$ Engineering = \int_{0}^{T} Programming \cdot d t $$

Here's one example of failure in CI caused by this mismatch (before PR #27 was rebased on top of this one):

https://github.com/ubuntu/wsl-setup/actions/runs/17502925193/job/49720222983#step:7:64

And here's a successful run of that same PR after rebasing on top of this one 🫤 :

https://github.com/ubuntu/wsl-setup/actions/runs/17503092367/job/49720720404?pr=27

After deploying this patch we get:

```
ubuntu@DESKTOP-551PQ9O:/mnt/c/Users/User$ systemctl status chrony
● chrony.service - chrony, an NTP client/server
     Loaded: loaded (/usr/lib/systemd/system/chrony.service; enabled; preset: enabled)
    Drop-In: /usr/lib/systemd/system/chrony.service.d
             └─wsl.conf
     Active: active (running) since Fri 2025-09-05 16:49:45 -03; 4s ago
 Invocation: 791cb90924cc42a9a845db7ff8dd874b
       Docs: man:chronyd(8)
             man:chronyc(1)
             man:chrony.conf(5)
   Main PID: 148 (chronyd-starter)
      Tasks: 3 (limit: 7087)
     Memory: 10.1M (peak: 10.9M)
        CPU: 90ms
     CGroup: /system.slice/chrony.service
             ├─148 /bin/sh /usr/lib/systemd/scripts/chronyd-starter.sh -n -F 1
             ├─215 /usr/sbin/chronyd -n -F 1 -x
             └─224 /usr/sbin/chronyd -n -F 1 -x

Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Disabled control of system clock
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Loaded 0 symmetric keys
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Using leap second list /usr/share/zoneinfo/leap-seconds.list
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Loaded seccomp filter (level 1)
Sep 05 16:49:45 DESKTOP-551PQ9O systemd[1]: Started chrony.service - chrony, an NTP client/server.
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Added pool 1.ntp.ubuntu.com
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Added pool 2.ntp.ubuntu.com
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Added pool 3.ntp.ubuntu.com
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Added pool 4.ntp.ubuntu.com
Sep 05 16:49:45 DESKTOP-551PQ9O chronyd[215]: Added pool ntp-bootstrap.ubuntu.com
```

