### PR TITLE
Fix the use of the `image_name` env var

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -138,7 +138,7 @@ jobs:
             packages: [hello]
         run: |
           # No launch so we can install the deb before running the OOBE
-          wsl --install --no-launch --from-file "./${{ env.images_dir }}/${image_name}" --name "${{ env.instance }}"
+          wsl --install --no-launch --from-file "${{ env.images_dir }}/${{ env.image_name }}" --name "${{ env.instance }}"
           wsl -d "${{ env.instance }}" -u root -- ls -l "./ci-artifacts/wsl-setup_*/"
           wsl -d "${{ env.instance }}" -u root -- dpkg -i "./ci-artifacts/wsl-setup_*/wsl-setup_*.deb"
 


### PR DESCRIPTION
Also prefers using the env context for ease reading logs.

That was the reason for the permission denied error: I should have written `${env: image_name}` instead of `${image_name}`, which results in `$null` and makes WSL attempt to read a folder as an image file, resulting in the permission denied error. The error message could be clearer, but in the end there is nothing wrong with GitHub runners.