### PR TITLE
docs: Add contributing guidelines to the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to `wsl-setup`
+
+A big welcome and thank you for considering contributing to `wsl-setup` and Ubuntu! It’s people like you that make it a reality for users in our community.
+
+Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the developers managing and developing this project. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Quick links
+
+* [Code of conduct](#code-of-conduct)
+* [Getting started](#getting-started)
+* [Issues](#issues)
+* [Pull requests](#pull-requests)
+* [Contributing to the code](#contributing-to-the-code)
+* [Contributor license agreement](#contributor-license-agreement)
+* [Getting help](#getting-help)
+
+## Code of conduct
+
+We take our community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://ubuntu.com/community/code-of-conduct).
+
+## Getting started
+
+Contributions are made to this project via issues and pull requests (PRs). A few general guidelines that cover both:
+
+* To report security vulnerabilities, please use the advisories page of the repository and not a public bug report. Please use [GitHub security advisories](https://github.com/ubuntu/wsl-setup/security/advisories/new) [launchpad private bugs](https://bugs.launchpad.net/ubuntu/+source/wsl-setup/+filebug) which is monitored by our security team. On an Ubuntu machine, it’s best to use `ubuntu-bug wsl-setup` to collect relevant information.
+* Search for existing issues and PRs on this repository before creating your own.
+* We work hard to makes sure issues are handled in a timely manner but, depending on the impact, it could take a while to investigate the root cause. A friendly ping in the comment thread to the submitter or a contributor can help draw attention if your issue is blocking.
+* If you've never contributed before, see [this Ubuntu community page](https://ubuntu.com/community/docs/contribute) for resources and tips on how to get started.
+
+### Issues
+
+Issues should be used to report problems with the software, request a new feature, or to discuss potential changes before a PR is created. When you create a new issue, a template will be loaded that will guide you through collecting and providing the information we need to investigate.
+
+If you find an issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help be indicating to our maintainers that a particular problem is affecting more than just the reporter.
+
+### Pull requests
+
+PRs to our project are always welcome and can be a quick way to get your fix or improvement slated for the next release. In general, PRs should:
+
+* Only fix/add the functionality in question **OR** address wide-spread whitespace/style issues, not both.
+* Add unit or integration tests for fixed or changed functionality.
+* Address a single concern in the least number of changed lines as possible.
+* Include documentation in the repo or on our [docs site](https://documentation.ubuntu.com/wsl).
+* Be accompanied by a complete pull request template (loaded automatically when a PR is created).
+
+For changes that address core functionality or would require breaking changes (e.g. a major release), it's best to open an issue to discuss your proposal first. This is not required but can save time creating and reviewing changes.
+
+In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susam/gitpr)
+
+1. Fork the repository to your own GitHub account
+1. Clone the project to your machine
+1. Create a branch locally with a succinct but descriptive name
+1. Commit changes to the branch
+1. Following any formatting and testing guidelines specific to this repo
+1. Push changes to your fork
+1. Open a PR in our repository and follow the PR template so that we can efficiently review the changes.
+
+> PRs will trigger unit and integration tests with and without race detection, linting and formatting validations, static and security checks, freshness of generated files verification. All the tests must pass before merging in main branch.
+
+Once merged to the main branch, `po` files and any documentation change will be automatically updated. Those are thus not necessary in the pull request itself to minimize diff review.
+
+## Contributing to the code
+
+### Building and running
+
+This project is packaged as a Debian package.
+
+To build from source, run the following command from the root folder of the repository.
+
+```bash
+debuild
+```
+
+The output will be available in the parent directory.
+
+Please see the [Ubuntu Packaging Guide](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com) for more details.
+
+### About the test suite
+
+The project includes a comprehensive test suite made of unit and integration tests. All the tests must pass before the review is considered. If you have troubles with the test suite, feel free to mention it on your PR description.
+
+Some of our tests utilize [expect](https://linux.die.net/man/1/expect) and supplementary shell scripts. Please see `test/` as well as the workflows and actions present in `.github/`.
+
+The test suite must pass before merging the PR to our main branch. Any new feature, change or fix must be covered by corresponding tests.
+
+### Code style
+
+This project utilizes [ShellCheck](https://github.com/koalaman/shellcheck) for static analysis of shell scripts.
+
+## Contributor license agreement
+
+It is required to sign the [Contributor License Agreement](https://ubuntu.com/legal/contributors) in order to contribute to this project.
+
+An automated test is executed on PRs to check if it has been accepted.
+
+This project is covered by [GPL-3.0](LICENSE).
+
+## Getting help
+
+Join us in the [Ubuntu Community](https://discourse.ubuntu.com/c/project/wsl/27) and post your question there with a descriptive tag.


### PR DESCRIPTION
This PR adds some contributing guidelines to the repository based on the desktop template.

Appropriate modifications were made to point to Ubuntu for WSL resources as well as resources specific to this project. 

---
[UDENG-8637](https://warthogs.atlassian.net/browse/UDENG-8637)

[UDENG-8637]: https://warthogs.atlassian.net/browse/UDENG-8637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ