### PR TITLE
Disable timesyncd by default

### DIFF
--- a/systemd/system/systemd-timesyncd.service.d/wsl.conf
+++ b/systemd/system/systemd-timesyncd.service.d/wsl.conf
@@ -1,7 +1,0 @@
-# Enable timesyncd on WSL machines
-# so WSL clock is synced on resume from suspend of the host.
-
-[Unit]
-ConditionVirtualization=
-ConditionVirtualization=|!container
-ConditionVirtualization=|wsl

--- a/test/systemd-assertions.sh
+++ b/test/systemd-assertions.sh
@@ -17,7 +17,7 @@ fi
 # Let's not worry about chrony just yet.
 nts_unit="systemd-timesyncd.service"
 if systemctl is-enabled "${nts_unit}"; then
-	if [[ $(LANG=C systemctl is-active "${nts_unit}") != "active" ]]; then
+	if [[ $(LANG=C systemctl is-active "${nts_unit}") != "inactive" ]]; then
 		echo "::error:: Unit ${nts_unit} should be enabled in WSL via ${nts_unit}.d/wsl.conf override"
 		systemctl status ${nts_unit}
 		exit 3

--- a/test/systemd-assertions.sh
+++ b/test/systemd-assertions.sh
@@ -14,11 +14,14 @@ if [[ $(LANG=C systemctl is-active multipathd.service) != "inactive" ]]; then
 	exit 2
 fi
 
+# It's been a while since WSL kernel implemented a patch specifically for time sync with Hyper-V.
+# With that NTS clients inside WSL instances can cause more trouble if they don't sync with the same
+# source as Windows does. So we're no longer overriding this systemd unit, let be the defaults.
 # Let's not worry about chrony just yet.
 nts_unit="systemd-timesyncd.service"
 if systemctl is-enabled "${nts_unit}"; then
 	if [[ $(LANG=C systemctl is-active "${nts_unit}") != "inactive" ]]; then
-		echo "::error:: Unit ${nts_unit} should be enabled in WSL via ${nts_unit}.d/wsl.conf override"
+		echo "::error:: Unit ${nts_unit} should be disabled by default."
 		systemctl status ${nts_unit}
 		exit 3
 	fi


### PR DESCRIPTION
Since https://github.com/microsoft/WSL2-Linux-Kernel/commit/a34090e9209d3d3db3d97aa567bb323ebc7620a4 WSL kernel carries a patch that significantly improves clock issues by forcing a time sync with hyper-v. It used to be a problem in the past, specially with system suspension or hibernation. For some users having Windows and Ubuntu syncing their clocks independently with different NTS servers causes clock jumps.
I'd say it's time to let WSL handle this by default and for the users that see a benefit in actually enabling NTS clients inside Ubuntu instances to add this override by themselves, we shall provide documentation about that ofc.

Closes: #28 

A consequence of this reasoning is that the PR that would override `chrony.service` is also not necessary. That service still needs a patch upstream to allow it running inside WSL for users who want it, but that's a topic for upstream chrony, not here.