### PR TITLE
fix(ubuntu-insights.sh): Update the Ubuntu Insights prompt to match the wording of GNOME control center

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wsl-setup (0.6.2ubuntu) resolute; urgency=medium
+
+  * Update the Ubuntu Insights prompt to match the wording of GNOME control center.
+
+ -- Kat Kuo <kat.kuo@canonical.com>  Thu, 05 Mar 2026 10:32:35 -0500
+
 wsl-setup (0.6.1) resolute; urgency=medium
 
   [ Kat Kuo]

--- a/ubuntu-insights.sh
+++ b/ubuntu-insights.sh
@@ -131,9 +131,8 @@ fi
 # Failed to read consent from the Windows registry, ask the user.
 echo "Help improve Ubuntu!
 
-You can share anonymous data with the Ubuntu development team so we can improve your experience.
-If you agree, we will collect and report anonymous hardware and system information.
-This information can't be used to identify a single machine.
+Help us improve Ubuntu features and compatibility by sharing system reports with Canonical.
+Reports are sent anonymously and do not contain any personal data.
 For legal details, please visit: https://ubuntu.com/legal/systems-information-notice
 
 We will save your answer to Windows and will only ask you once.


### PR DESCRIPTION
Here, we standardize the prompt shown for Ubuntu Insights consent so that it matches the wording of GNOME control center. 

This is only a change to the description of what this is, the parts related to the link to the privacy notice and the information on saving the user's answer to Windows are unchanged.

```
Help improve Ubuntu!

Help us improve Ubuntu features and compatibility by sharing system reports with Canonical.
Reports are sent anonymously and do not contain any personal data.
For legal details, please visit: https://ubuntu.com/legal/systems-information-notice

We will save your answer to Windows and will only ask you once.
```

Additionally, we create a new changelog entry, bumping the version to `0.6.2ubuntu`, following the new standard for native packaging versioning.