### PR TITLE
fix(CI): Shutdown the WSL VM before validating the instance state in integration tests

### DIFF
--- a/.github/actions/get-wsl-image/action.yaml
+++ b/.github/actions/get-wsl-image/action.yaml
@@ -47,12 +47,14 @@ runs:
           exit 2
         fi
 
-        # Extract the SHA (first field) and image name (second field without the *)
+        # Extract the SHA (first field), image name (second field without the *) and manifest.
         sha=$(echo "$line" | awk '{print $1}')
         image_name=$(echo "$line" | awk '{print $2}' | sed 's/^\*//')
+        image_manifest=$(echo "$image_name" | sed -E 's/\.wsl$/.manifest/')
 
         echo "cache-key=$sha" >> "$GITHUB_OUTPUT"
         echo "image-name=$image_name" >> "$GITHUB_OUTPUT"
+        echo "image-manifest=$image_manifest" >> "$GITHUB_OUTPUT"
 
     - name: Validate image
       id: check-locally
@@ -116,3 +118,22 @@ runs:
         path: ${{ inputs.output_path }}
         key: ${{ steps.restore-cache.outputs.cache-primary-key }}
         enableCrossOsArchive: true
+
+    - name: Save image manifest for future troubleshooting
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        uri="${{ inputs.base_url }}/${{ steps.compute-cache-key.outputs.image-manifest }}"
+        manifest_path="${{ runner.temp }}/image.manifest"
+        if ! curl --fail -o "$manifest_path" "$uri"; then
+            echo "::error:: Failed to download the WSL image manifest from $uri. This is not a critical failure, but may make troubleshooting harder in the future."
+        else
+            echo "Image manifest downloaded to $manifest_path"
+        fi
+    - uses: actions/upload-artifact@v7
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+      with:
+        name: ${{ steps.compute-cache-key.outputs.image-name }}.manifest
+        path: "${{ runner.temp }}/image.manifest"

--- a/.github/actions/validate-wsl/action.yaml
+++ b/.github/actions/validate-wsl/action.yaml
@@ -31,10 +31,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Terminate WSL instance
+    - name: Shutdown WSL for a clean start
       shell: powershell
       run: |
-        wsl --terminate ${{ inputs.instance }}
+        wsl --shutdown
 
     - name: Checkout scripts into WSL
       uses: ubuntu/WSL/.github/actions/wsl-checkout@main


### PR DESCRIPTION
It looks like a shutdown of WSL before validating the image is beneficial in CI, we had three successful runs in a row after replacing `wsl --terminate instance` with `wsl --shutdown`, see [1](https://github.com/ubuntu/wsl-setup/actions/runs/23439953757), [2](https://github.com/ubuntu/wsl-setup/actions/runs/23440423370) and [3](https://github.com/ubuntu/wsl-setup/actions/runs/23441471549).

Some historical facts to get started:

- Last in-sequence successful integration test happened on Jan 20th, 2026
- WSL was upgraded in GH runners on Jan 9th, we had at least one successful in-sequence run with that version of WSL. Since then no changes to WSL in GH hosted runners.
- The version of cloud-init on the last successful and the first failed runs were the same: v25.3.
- Recent images of resolute come with cloud-init v26.1
- The last CI failure was already running with that image.

So it doesn’t seem a particular issue with a version of cloud-init or WSL.

The symptom is always the same (not easily reproducible locally):

```
 UNIT              LOAD   ACTIVE SUB    DESCRIPTION
● user@1001.service loaded failed failed User Manager for UID 1001

Legend: LOAD   → Reflects whether the unit definition was properly loaded.
        ACTIVE → The high-level unit activation state, i.e. generalization of SUB.
        SUB    → The low-level unit activation state, values depend on unit type.

1 loaded units listed.
```

My small historical analysis since a little before the failure trend started until now didn't reveal any culprits or even suspects, but I realized that it would be nice to have kept the image manifests over time to compare the packages and versions. This doesn't seem the particular case where having that would help, but future problem solving might benefit from this idea, so I'm modifying the `get-wsl-image` action to download the image manifest and upload it as a CI artefact.

---

UDENG-9298