### PR TITLE
feat: refresh color palette and update terminal font to Ubuntu Sans Mono

### DIFF
--- a/wsl-setup
+++ b/wsl-setup
@@ -101,7 +101,7 @@ function install_ubuntu_font() {
 
 	local_app_data=$(wslpath -au "${local_app_data}") 2>/dev/null || true
 	local fonts_dir="${local_app_data}/Microsoft/Windows/Fonts"
-	local font="UbuntuMono[wght].ttf"
+	local font="UbuntuSansMono[wght].ttf"
 	mkdir -p "${fonts_dir}" 2>/dev/null
 	if [ -f "${fonts_dir}/${font}" ]; then
 		return

--- a/wsl/terminal-profile.json
+++ b/wsl/terminal-profile.json
@@ -5,8 +5,8 @@
             "suppressApplicationTitle": true,
             "cursorShape": "filledBox",
             "font": {
-                "face": "Ubuntu Mono",
-                "size": 13
+                "face": "Ubuntu Sans Mono",
+                "size": 12
             }
         }
     ],
@@ -14,25 +14,48 @@
         {
             "name": "Ubuntu",
             "background": "#300A24",
-            "black": "#171421",
-            "blue": "#0037DA",
-            "brightBlack": "#767676",
-            "brightBlue": "#08458F",
-            "brightCyan": "#2C9FB3",
-            "brightGreen": "#26A269",
-            "brightPurple": "#A347BA",
-            "brightRed": "#C01C28",
-            "brightWhite": "#F2F2F2",
-            "brightYellow": "#A2734C",
+            "black": "#1B1B1B",
+            "blue": "#3667A6",
+            "brightBlack": "#838383",
+            "brightBlue": "#729FCF",
+            "brightCyan": "#34E2E2",
+            "brightGreen": "#8AE234",
+            "brightPurple": "#AD7FA8",
+            "brightRed": "#F93632",
+            "brightWhite": "#EEEEEC",
+            "brightYellow": "#FCE94F",
             "cursorColor": "#FFFFFF",
-            "cyan": "#3A96DD",
+            "cyan": "#06989A",
             "foreground": "#FFFFFF",
-            "green": "#26A269",
-            "purple": "#881798",
-            "red": "#C21A23",
+            "green": "#4E9A06",
+            "purple": "#7F5985",
+            "red": "#CC1A12",
             "selectionBackground": "#FFFFFF",
-            "white": "#CCCCCC",
-            "yellow": "#A2734C"
+            "white": "#D5D5D5",
+            "yellow": "#C4A000"
+        },
+        {
+            "name": "Ubuntu Light",
+            "background": "#F8F8F8",
+            "black": "#F2F2F2",
+            "blue": "#5B91D7",
+            "brightBlack": "#707070",
+            "brightBlue": "#395E86",
+            "brightCyan": "#064141",
+            "brightGreen": "#26420C",
+            "brightPurple": "#80577C",
+            "brightRed": "#CE191C",
+            "brightWhite": "#212121",
+            "brightYellow": "#80721B",
+            "cursorColor": "#121212",
+            "cyan": "#047B7D",
+            "foreground": "#121212",
+            "green": "#3F7E04",
+            "purple": "#A77DAD",
+            "red": "#F93B2E",
+            "selectionBackground": "#000000",
+            "white": "#1B1B1B",
+            "yellow": "#A88F00"
         }
     ]
 }


### PR DESCRIPTION
Update the bundled Windows Terminal profile to the new terminal theme in Ubuntu since 26.04. Changes improve accessibility with more uniform shades, and adds a new Ubuntu Light color scheme. Minor adjustments too to font size (down from 13pt to 12pt) and font family (from Ubuntu Mono to Ubuntu Sans Mono).

**Changes:**
- `wsl/terminal-profile.json`: font face and size updated; Ubuntu dark palette refreshed; Ubuntu Light palette added
- `wsl-setup`: install `UbuntuSansMono[wght].ttf` instead of `UbuntuMono[wght].ttf`

UDENG-10555