### PR TITLE
fix(wsl-setup): Font face name in the Registry value must match

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wsl-setup (0.6.3ubuntu) stonking; urgency=medium
+
+  * Sync terminal profile with the Desktop theme (LP: #2156047)
+
+ -- Carlos Nihelton <cnihelton@ubuntu.com> Tue, 09 Jun 2026 08:54:42 -0300
+
 wsl-setup (0.6.2ubuntu) resolute; urgency=medium
 
   * Match the Ubuntu Insights prompt with GNOME control center (LP: #2143563)

--- a/wsl-setup
+++ b/wsl-setup
@@ -115,7 +115,7 @@ function install_ubuntu_font() {
 	# shellcheck disable=SC2016 # Intentional due to how we use powershell
 	powershell.exe -NoProfile -Command '& {
               $null = New-Item -Path "HKCU:\Software\Microsoft\Windows NT\CurrentVersion" -Name "Fonts" 2>$null;
-              $null = New-ItemProperty -Name "Ubuntu Mono (TrueType)" -Path "HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Fonts" -PropertyType string -Value "'"${dst}"'" 2>$null;
+              $null = New-ItemProperty -Name "Ubuntu Sans Mono (TrueType)" -Path "HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Fonts" -PropertyType string -Value "'"${dst}"'" 2>$null;
   }' >/dev/null || true
 }
 


### PR DESCRIPTION
We refer to it as 'Ubuntu Sans Mono' in the terminal profile fragment https://github.com/ubuntu/wsl-setup/blob/main/wsl/terminal-profile.json#L8 The exact name must be in the Registry value name then.

That was an oversight from the previous PR I only noticed when the terminal complained about not finding the font even though the TTF file was at the right location.

UDENG-10557