### PR TITLE
fix: Change package architecture from 'any' to 'all' in control file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wsl-setup (0.6.4ubuntu) stonking; urgency=medium
+
+  * Change package architecture to 'all' in the control file 
+
+ -- Kat Kuo <kat.kuo@canonical.com>  Thu, 11 Jun 2026 12:21:34 -0400
+
 wsl-setup (0.6.3ubuntu) stonking; urgency=medium
 
   * Sync terminal profile with the Desktop theme (LP: #2156047)

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Description: WSL integration setup
  enabled by default.
 
 Package: wsl-setup
-Architecture: any
+Architecture: all
 Depends: adduser,
          cloud-init,
          fonts-ubuntu,


### PR DESCRIPTION
We don't have anything compiled, so we should change the architecture to 'all'.

---
[UDENG-10679](https://warthogs.atlassian.net/browse/UDENG-10679)

[UDENG-10679]: https://warthogs.atlassian.net/browse/UDENG-10679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ