### PR TITLE
fix(deps): add .github/actions to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,9 +3,11 @@ updates:
   # Infrastructure
   ## GitHub Actions
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
+    # Workflow files in `.github/workflows` (default) and
+    # composite actions under `.github/actions`
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
       day: "thursday"


### PR DESCRIPTION
Small fix to get Dependabot to also update things under `.github/actions`. By default, it's only scanning under `.github/workflows`.