### PR TITLE
fix: Exports LC_* variables into the user session ...

### DIFF
--- a/.github/actions/validate-wsl/action.yaml
+++ b/.github/actions/validate-wsl/action.yaml
@@ -48,6 +48,7 @@ runs:
         distro: ${{ inputs.instance }}
         working-dir: ${{ inputs.working-dir }}
         exec: |
+          source /etc/profile
           source test/basic-assertions.sh "${{ inputs.expected-user }}"
 
     - name: Run font installation assertions

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,6 +12,7 @@ env:
   instance_working_dir: ~/wsl-setup-${{ github.run_id }}
   insights_registry_key_path: "HKCU:\\Software\\Canonical\\Ubuntu"
   insights_registry_value_name: "UbuntuInsightsConsent"
+  custom_locale: pt_BR.UTF-8
 
 jobs:
   build-deb:
@@ -84,9 +85,10 @@ jobs:
         shell: powershell
         env:
           WSL_UTF8: "1" # Recommended otherwise it's hard to read wsl output on Github
-          # Just to skip the interactive session
+          # To skip the interactive session and configure the system's desired state.
           cloudinit: |
             #cloud-config
+            locale: en_US.UTF-8
             users:
             - name: u
               gecos: Ubuntu User
@@ -94,6 +96,10 @@ jobs:
               sudo: ALL=(ALL) NOPASSWD:ALL
               shell: /bin/bash
             packages: [hello]
+            # Sets numeric output in the ${{ env.custom_locale }} locale, while everything else remains in en_US.UTF-8.
+            runcmd:
+            - locale-gen ${{ env.custom_locale }}
+            - update-locale LC_NUMERIC=${{ env.custom_locale }}
             write_files:
             - path: /etc/wsl.conf
               append: true
@@ -311,6 +317,14 @@ jobs:
 
           # Run the expect script
           wsl -d "${{ env.instance }}" -u root -- expect /tmp/setup.expect "${{ env.username }}" "${{ env.password }}" "${{ matrix.consent }}"
+
+      - name: Set up custom locale for testing
+        shell: powershell
+        env:
+          WSL_UTF8: "1"
+        run: |
+          wsl -d "${{ env.instance }}" -u root -- locale-gen ${{ env.custom_locale }}
+          wsl -d "${{ env.instance }}" -u root -- update-locale LC_NUMERIC=${{ env.custom_locale }}
 
       - name: Validate instance state
         uses: ./.github/actions/validate-wsl

--- a/90-wsl-env-bridge.sh
+++ b/90-wsl-env-bridge.sh
@@ -10,7 +10,7 @@ if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
 	# shellcheck disable=SC2163 # Intentionally exporting the contents, not the variable itself.
         export "$line"
       fi
-    done < <(systemctl show-environment)
+    done < <(systemctl show-environment 2>/dev/null)
 else
     echo "This script is intended to be sourced in a bash or zsh shell."
 fi 

--- a/90-wsl-env-bridge.sh
+++ b/90-wsl-env-bridge.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script is used to bridge environment variables seeing by systemd into the environment of a user shell session
+# by means of re-exporting the output of (systemctl show-environment) into the shell session.
+
+if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
+    # Export the environment variables from systemd into the current shell session
+    while IFS='=' read -r line; do
+      # For now at least only exporting locale-related variables.
+      if [[ "$line" =~ ^(LANG|LC_[A-Z]+)= ]]; then
+	# shellcheck disable=SC2163 # Intentionally exporting the contents, not the variable itself.
+        export "$line"
+      fi
+    done < <(systemctl show-environment)
+else
+    echo "This script is intended to be sourced in a bash or zsh shell."
+fi 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,12 @@
 wsl-setup (0.6.4ubuntu) stonking; urgency=medium
 
+  [ Kat Kuo ]
   * Change package architecture to 'all' in the control file 
+  [ Carlos Nihelton ]
+  * Export LC_* variables to the user session as shown by `systemctl
+    show-environment`.
 
- -- Kat Kuo <kat.kuo@canonical.com>  Thu, 11 Jun 2026 12:21:34 -0400
+ -- Kat Kuo <kat.kuo@canonical.com>  Tue, 23 Jun 2026 12:21:34 -0400
 
 wsl-setup (0.6.3ubuntu) stonking; urgency=medium
 

--- a/debian/install
+++ b/debian/install
@@ -1,7 +1,8 @@
+90-wsl-env-bridge.sh etc/profile.d/
 cloud/ etc/
-update-motd.d/99-wsl etc/update-motd.d/
 systemd/ usr/lib/
 ubuntu-insights.sh usr/lib/wsl/
-wsl-setup usr/lib/wsl/
+update-motd.d/99-wsl etc/update-motd.d/
 wait-for-cloud-init usr/lib/wsl/
+wsl-setup usr/lib/wsl/
 wsl/ usr/share/

--- a/test/basic-assertions.sh
+++ b/test/basic-assertions.sh
@@ -28,3 +28,24 @@ if [[ $(whoami) != "$EXPECTED_USER" ]]; then
 	echo "::error:: Default user doesn't match expected user '$EXPECTED_USER'."
 	exit 4
 fi
+
+# WSL only sets LANG from /etc/default/locale. We attempt to set the LC_* variables from the systemd
+# environment. This test assumes that cloud-init set locale to en_US.UTF-8 but LC_NUMERIC to
+# pt_BR.UTF-8 if systemd is ON (see .github/workflows/integration.yaml:15).
+# Without systemd and cloud-init the default locale would be C.UTF-8 so the expectations still hold.
+expected="C.UTF-8"
+systemd_running="OFF"
+if systemctl is-system-running --quiet; then
+	expected="pt_BR.UTF-8"
+	systemd_running="ON"
+fi
+if [[ "$LC_NUMERIC" != "$expected" ]]; then
+	echo "::error:: With systemd $systemd_running, expected LC_NUMERIC to be $expected but got $LC_NUMERIC."
+	echo "Expected locale:"
+	cat /etc/default/locale
+	echo "got locale:"
+	locale
+	echo "systemd environment:"
+	systemctl show-environment
+	exit 5
+fi


### PR DESCRIPTION
... as shown by `systemctl show-environment`.

WSL2 doesn't go through PAM when creating the user session, so `pam_env.so` doesn't have the chance to export some interesting environment variables, such as the locale related ones.

WSL2 init itself does export `LANG` if found in the `locale.conf` file, but only that var, no others.

This PR adds a shell script into `/etc/profile.d` that reads the output of `systemctl show-environment` and exports the variables it's interested in. This way we delegate to systemd to actually read and parse the multiple files that might be interesting for this purpose.

Other variable patterns might be added to that regex as we find more interesting use cases. But we need to be careful: if we didn't filter it we'd end up overwriting `PATH` with a much smaller scope.

Here's how a system set up per the description in #313 would look like with this patch in place:

```
u@DESKTOP-551PQ9O:~$ locale
LANG=C.UTF-8
LANGUAGE=
LC_CTYPE="C.UTF-8"
LC_NUMERIC="C.UTF-8"
LC_TIME="C.UTF-8"
LC_COLLATE="C.UTF-8"
LC_MONETARY="C.UTF-8"
LC_MESSAGES=de_DE.UTF-8
LC_PAPER="C.UTF-8"
LC_NAME="C.UTF-8"
LC_ADDRESS="C.UTF-8"
LC_TELEPHONE="C.UTF-8"
LC_MEASUREMENT="C.UTF-8"
LC_IDENTIFICATION="C.UTF-8"
LC_ALL=
u@DESKTOP-551PQ9O:~$ systemctl show-environment
LANG=C.UTF-8
LC_MESSAGES=de_DE.UTF-8
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
u@DESKTOP-551PQ9O:~$ cat /etc/default/locale
LANG=C.UTF-8
LC_MESSAGES=de_DE.UTF-8
u@DESKTOP-551PQ9O:~$
```

Fixes https://github.com/ubuntu/WSL/issues/313

---
UDENG-220